### PR TITLE
Create mysql dockerfile

### DIFF
--- a/dockerfiles/mysqldump/Dockerfile
+++ b/dockerfiles/mysqldump/Dockerfile
@@ -1,0 +1,61 @@
+# ---- Stage 1: Build mysqldump from MySQL source ----
+FROM cgr.dev/chainguard/wolfi-base:latest AS builder
+
+# Install build dependencies only
+RUN apk add --no-cache \
+    build-base \
+    cmake \
+    ncurses-dev \
+    bison \
+    openssl-dev \
+    zlib-dev \
+    boost-dev \
+    curl-dev \
+    libedit-dev \
+    libtirpc-dev \
+    git \
+    bash \
+    make \
+    xz \
+    binutils
+
+# Set working directory
+WORKDIR /build
+
+# Shallow clone only needed branch and minimal history
+RUN git clone --branch mysql-8.0.42 --depth 1 https://github.com/mysql/mysql-server.git
+
+# Create build dir outside source
+RUN mkdir /build/build-dir
+
+WORKDIR /build/build-dir
+
+# Configure cmake build
+RUN cmake ../mysql-server \
+    -DDOWNLOAD_BOOST=1 \
+    -DWITH_BOOST=boost \
+    -DWITH_UNIT_TESTS=OFF \
+    -DWITHOUT_SERVER=ON \
+    -DWITH_EDITLINE=bundled \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_FLAGS="-O3" \
+    -DCMAKE_CXX_FLAGS="-O3"
+
+# Build and install
+RUN make -j$(nproc) client
+RUN make -j$(nproc) install
+
+# ---- Stage 2: Final minimal runtime image ----
+FROM cgr.dev/chainguard/wolfi-base:latest
+
+# Install runtime requirements and bash
+RUN apk add --no-cache bash
+
+# Copy only the stripped mysqldump binary
+COPY --from=builder /usr/local/mysql/bin/mysqldump /usr/local/bin/
+
+# Ensure executable permissions
+RUN chmod +x /usr/local/bin/mysqldump
+
+# Default shell
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Adds a new Dockerfile for building a minimal `mysqldump` image

- Implements multi-stage build for optimized image size

- Compiles `mysqldump` from MySQL 8.0.42 source

- Ensures only essential runtime dependencies are included


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Stage 1: Build mysqldump from source"] -- "Compile & install" --> B["mysqldump binary"]
  B -- "Copy binary" --> C["Stage 2: Minimal runtime image"]
  C -- "Set up entrypoint" --> D["Ready-to-use mysqldump image"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add multi-stage Dockerfile for minimal mysqldump image</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dockerfiles/mysqldump/Dockerfile

<ul><li>Adds a new multi-stage Dockerfile for <code>mysqldump</code><br> <li> Builds <code>mysqldump</code> from MySQL 8.0.42 source<br> <li> Installs only essential build and runtime dependencies<br> <li> Produces a minimal image with just the <code>mysqldump</code> binary</ul>


</details>


  </td>
  <td><a href="https://github.com/proteantecs/mlrun/pull/8/files#diff-509da6d561a826dcc048200d32ffea415974780b4508e0aa5f8e204b75c01fec">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

