### PR TITLE
fix: resolve mysqldump binary not found error in Docker build

### DIFF
--- a/dockerfiles/mysqldump/Dockerfile
+++ b/dockerfiles/mysqldump/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /build/build-dir
 
 WORKDIR /build/build-dir
 
-# Configure cmake build
+# Configure cmake build with explicit install prefix
 RUN cmake ../mysql-server \
     -DDOWNLOAD_BOOST=1 \
     -DWITH_BOOST=boost \
@@ -38,6 +38,7 @@ RUN cmake ../mysql-server \
     -DWITHOUT_SERVER=ON \
     -DWITH_EDITLINE=bundled \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local/mysql \
     -DCMAKE_C_FLAGS="-O3" \
     -DCMAKE_CXX_FLAGS="-O3"
 
@@ -45,14 +46,28 @@ RUN cmake ../mysql-server \
 RUN make -j$(nproc) client
 RUN make -j$(nproc) install
 
+# Find and copy mysqldump to a known location for easier copying
+RUN MYSQLDUMP_PATH=$(find /usr/local -name "mysqldump" -type f 2>/dev/null | head -1) && \
+    if [ -z "$MYSQLDUMP_PATH" ]; then \
+        echo "ERROR: mysqldump binary not found!" && exit 1; \
+    else \
+        echo "Found mysqldump at: $MYSQLDUMP_PATH" && \
+        mkdir -p /tmp/mysql-bin && \
+        cp "$MYSQLDUMP_PATH" /tmp/mysql-bin/mysqldump && \
+        chmod +x /tmp/mysql-bin/mysqldump; \
+    fi
+
 # ---- Stage 2: Final minimal runtime image ----
 FROM cgr.dev/chainguard/wolfi-base:latest
 
 # Install runtime requirements and bash
 RUN apk add --no-cache bash
 
-# Copy only the stripped mysqldump binary
-COPY --from=builder /usr/local/mysql/bin/mysqldump /usr/local/bin/
+# Create the user for mlrun
+RUN adduser -u 1000 -D mlrun
+
+# Copy the mysqldump binary from the known temporary location
+COPY --from=builder /tmp/mysql-bin/mysqldump /usr/local/bin/mysqldump
 
 # Ensure executable permissions
 RUN chmod +x /usr/local/bin/mysqldump


### PR DESCRIPTION
### **User description**
- Add explicit CMAKE_INSTALL_PREFIX to ensure mysqldump is installed to expected location
- Implement robust binary location detection using find command
- Copy mysqldump to predictable temporary location in builder stage
- Fix user creation to use adduser compatible with Alpine/Wolfi base images
- Add error handling for missing mysqldump binary

This fixes the Docker build error: failed to calculate checksum - mysqldump not found


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Set explicit CMAKE_INSTALL_PREFIX for predictable mysqldump location

- Add robust mysqldump binary detection and error handling

- Copy mysqldump to a temporary location for reliable Docker copying

- Update user creation for compatibility with Alpine/Wolfi images


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMake install with explicit prefix"] -- "Ensures predictable binary location" --> B["Find mysqldump with find command"]
  B -- "Copy to /tmp/mysql-bin" --> C["mysqldump available for COPY"]
  C -- "COPY to runtime image" --> D["mysqldump in /usr/local/bin"]
  E["Add user with adduser"] -- "Ensures compatibility" --> F["Final runtime image"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Robust mysqldump binary handling and user creation in Dockerfile</code></dd></summary>
<hr>

dockerfiles/mysqldump/Dockerfile

<ul><li>Set explicit <code>CMAKE_INSTALL_PREFIX</code> for MySQL build<br> <li> Add script to robustly find and copy <code>mysqldump</code> binary<br> <li> Implement error handling if <code>mysqldump</code> not found<br> <li> Update user creation to use <code>adduser</code> for Alpine/Wolfi compatibility<br> <li> Change binary copy to use temporary location for reliability</ul>


</details>


  </td>
  <td><a href="https://github.com/proteantecs/mlrun/pull/10/files#diff-509da6d561a826dcc048200d32ffea415974780b4508e0aa5f8e204b75c01fec">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

